### PR TITLE
readme: fix import Roles example at Usage topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install @alanning/roles --save
 
 In your app code:
 ```js
-import Roles from '@alanning/roles'
+import {Roles} from '@alanning/roles'
 import { MongoClient } from 'mongodb'
 
 // MongoDB connection

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install @alanning/roles --save
 
 In your app code:
 ```js
-import {Roles} from '@alanning/roles'
+import { Roles } from '@alanning/roles'
 import { MongoClient } from 'mongodb'
 
 // MongoDB connection


### PR DESCRIPTION
I was trying to use `@alanning/roles` package due to the example in readme. So I have got an error `TypeError: _context.t0 is not a constructor`, which mean `Roles` class is `undefined`, so it's not working with the default import. 
The problem was fixed, after I import directly `Roles` from `@alanning/roles` package:
```javascript
import { Roles } from '@alanning/roles';
```
The purpose of the change is to avoid confusions between examples and real usage.